### PR TITLE
Grammar Correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It is based on [jump for Windows by Frederic Seiler](https://github.com/frederic
 
 ## Installation
 
-To be the most useful the script should be sourced when powershell is started. I personally use the following method but if you already use a powershell profile your requirements might differ (though most people with a powershell profile will know a way to source this script themselfes)
+To be the most useful the script should be sourced when powershell is started. I personally use the following method but if you already use a powershell profile your requirements might differ (though most people with a powershell profile will know a way to source this script themselves)
 
 In Powershell get the Path to your $profile
 


### PR DESCRIPTION
**Changed "themselfes" to "themselves"**

> Although some current dictionaries, for example, The New Oxford Dictionary of English, state that themself has re-emerged in recent years when used to refer to a singular gender-neutral noun or pronoun ("themselves" remains the normal third person plural reflexive form), they label it as "rare" or "disputed" or "not widely accepted in standard English".

(Source: https://www.justice.gc.ca/eng/rp-pr/csj-sjc/legis-redact/legistics/p1p30.html)